### PR TITLE
005 Discovered Errors

### DIFF
--- a/logic_hortence/cerulean.json
+++ b/logic_hortence/cerulean.json
@@ -169,7 +169,7 @@
             "name": "Wheels Chapmion",
             "item_count": 1,
             "access_rules": [
-              "figurine_mage"
+              "figurine_mage,wheelstable"
             ]
           }
         ],
@@ -192,7 +192,7 @@
             ]
           },
           {
-            "name": "North Pointer (4) Bottom Left",
+            "name": "North Pointer (4) Bottom Right",
             "item_count": 1,
             "access_rules": [
               "probe"

--- a/logic_hortence/evermist.json
+++ b/logic_hortence/evermist.json
@@ -31,7 +31,7 @@
             "item_count": 1,
             "chest_opened_img": "images/boxes/basket_open.png",
             "chest_unopened_img": "images/boxes/basket_closed.png",
-            "restrict_visibility_rules": [
+            "visibility_rules": [
               "option_skip_prologue_off"
             ]
           },
@@ -267,11 +267,18 @@
         "sections": [
           {
             "name": "Cooking with Garl",
-            "item_count": 1
+            "hosted_item": "food_berryjam"
           },
           {
             "name": "Free Recipes",
             "item_count": 4
+          },
+          {
+            "name": "Reclamation",
+            "item_count": 1,
+            "access_rules": [
+              "boss_elysandarelle,rainbowstar,locket,boss_croustalion,boss_gungoddess,boss_eldermist_2,boss_seaslug"
+            ]
           }
         ],
         "map_locations": [
@@ -318,15 +325,21 @@
             "item_count": 1
           },
           {
+            "name": "Graplou Island",
+            "item_count": 1,
+            "chest_unopened_img": "images/boxes/conch_chest_closed.png",
+            "chest_opened_img": "images/boxes/conch_chest_open.png",
+            "access_rules": [
+              "graplou"
+            ]
+          },
+          {
             "name": "Pine Path",
             "item_count": 1
           },
           {
-            "name": "Graplou Island",
-            "item_count": 1,
-            "access_rules": [
-              "graplou"
-            ]
+            "name": "Rope Cave",
+            "item_count": 1
           },
           {
             "name": "Mist Falls",

--- a/logic_hortence/mesa.json
+++ b/logic_hortence/mesa.json
@@ -100,7 +100,7 @@
         "name": "Bamboo Creek",
         "access_rules": [
           "@Autumn Hills/Past Prism,magicseashell",
-          "boss_dweller_of_dread"
+          "boss_dweller_dread"
         ],
         "sections": [
           {
@@ -126,7 +126,7 @@
         "name": "Songshroom Marsh",
         "access_rules": [
           "@Autumn Hills/Past Prism,magicseashell",
-          "boss_dweller_of_dread"
+          "boss_dweller_dread"
         ],
         "sections": [
           {
@@ -226,7 +226,8 @@
       {
         "name": "Clockwork Castle Grounds",
         "access_rules": [
-          "@Songshroom Marsh/Yomara's Gate"
+          "@Songshroom Marsh/Yomara's Gate",
+          "boss_dweller_dread"
         ],
         "sections": [
           {
@@ -278,24 +279,39 @@
             ]
           },
           {
-            "name": "2F Left",
+            "name": "Push Ladder",
             "item_count": 1,
             "access_rules": [
               "@Clockwork Castle/Beyond Garden"
             ]
           },
           {
-            "name": "2F Left",
+            "name": "3F Right",
             "item_count": 1,
             "access_rules": [
               "@Clockwork Castle/Beyond Garden"
             ]
           },
           {
-            "name": "2F Left",
+            "name": "Watchmaker's Workshop",
             "item_count": 1,
             "access_rules": [
               "@Clockwork Castle/Beyond Garden"
+            ]
+          },
+          {
+            "name": "Buy From Watchmaker",
+            "item_count": 1,
+            "access_rules": [
+              "@Clockwork Castle/Beyond Garden,@reg_seraiworld"
+            ]
+          },
+          {
+            "name": "Wheels Master",
+            "item_count": 1,
+            "hosted_item": "flimsyhammers",
+            "access_rules": [
+              "@Clockwork Castle/Beyond Garden,wheel_platinum,wheelstable"
             ]
           },
           {

--- a/logic_hortence/serai_overworld.json
+++ b/logic_hortence/serai_overworld.json
@@ -11,9 +11,7 @@
     "children": [
       {
         "name": "Sea of Stars",
-        "access_rules": [
-          
-        ],
+        "access_rules": [],
         "sections": [
           {
             "name": "Guardian",
@@ -119,17 +117,17 @@
             "item_count": 3
           },
           {
-            "name": "Mines Illusion",
+            "name": "Catch Fish?",
             "item_count": 1,
             "access_rules": [
               "key_bigjar:3"
             ]
           },
           {
-            "name": "Catch Fish?",
+            "name": "Mines Illusion",
             "item_count": 1,
             "access_rules": [
-              "key_bigjar:3"
+              "key_bigjar:3, key_susfish"
             ]
           },
           {
@@ -149,6 +147,13 @@
           {
             "name": "Phase Reaper",
             "hosted_item": "boss_phasereaper",
+            "access_rules": [
+              "key_bigjar:3, key_susfish"
+            ]
+          },
+          {
+            "name": "Soul Curator",
+            "hosted_item": "boss_curator",
             "access_rules": [
               "key_bigjar:3, key_susfish"
             ]

--- a/logic_hortence/sleeper.json
+++ b/logic_hortence/sleeper.json
@@ -75,11 +75,11 @@
             "item_count": 1
           },
           {
-            "name": "Srowers Cave",
+            "name": "Pond",
             "item_count": 1
           },
           {
-            "name": "Pond",
+            "name": "Srowers Cave",
             "item_count": 1
           },
           {
@@ -125,6 +125,13 @@
             "chest_opened_img": "images/boxes/conch_chest_open.png",
             "access_rules": [
               "mistral"
+            ]
+          },
+          {
+            "name": "Wheels Champion",
+            "item_count": 1,
+            "access_rules": [
+              "figurine_mage"
             ]
           },
           {
@@ -204,6 +211,8 @@
           {
             "name": "2B Left Side",
             "item_count": 1,
+            "chest_unopened_img": "images/boxes/basket_closed.png",
+            "chest_opened_img": "images/boxes/basket_open.png",
             "access_rules": [
               "mistral"
             ]
@@ -217,7 +226,10 @@
           },
           {
             "name": "Malkomount",
-            "hosted_item": "boss_malkomount"
+            "hosted_item": "boss_malkomount",
+            "access_rules": [
+              "mistral"
+            ]
           }
         ],
         "map_locations": [
@@ -254,7 +266,9 @@
           },
           {
             "name": "West Edge",
-            "item_count": 1
+            "item_count": 1,
+            "chest_unopened_img": "images/boxes/basket_closed.png",
+            "chest_opened_img": "images/boxes/basket_open.png"
           },
           {
             "name": "Lower Mistral Spinner",
@@ -347,21 +361,18 @@
             "chest_opened_img": "images/boxes/conch_chest_open.png"
           },
           {
-            "name": "Push Crate",
+            "name": "Fireplace Top",
             "item_count": 1,
             "chest_unopened_img": "images/boxes/conch_chest_closed.png",
-            "chest_opened_img": "images/boxes/conch_chest_open.png",
-            "visibility_rules": [
-              ""
-            ]
+            "chest_opened_img": "images/boxes/conch_chest_open.png"
           },
           {
             "name": "Rubble Secret",
             "item_count": 1,
             "chest_unopened_img": "images/boxes/conch_chest_closed.png",
             "chest_opened_img": "images/boxes/conch_chest_open.png",
-            "visibility_rules": [
-              ""
+            "access_rules": [
+              "[mistral]"
             ]
           },
           {
@@ -403,6 +414,13 @@
             "item_count": 1,
             "access_rules": [
               "figurine_mage"
+            ]
+          },
+          {
+            "name": "Golden Pelican",
+            "item_count": 2,
+            "access_rules": [
+              "invitation"
             ]
           }
         ],
@@ -457,6 +475,41 @@
             "restrict_visibility_rules": [
               "event_cataclysm"
             ]
+          }
+        ]
+      },
+      {
+        "name": "Dweller's Fall Arena",
+        "access_rules": [
+          "@reg_sleeper_sealevel,boss_dweller_dread"
+        ],
+        "sections": [
+          {
+            "name": "Rank",
+            "hosted_item": "boss_arena"
+          },
+          {
+            "name": "Bronze",
+            "item_count": 1
+          },
+          {
+            "name": "Silver",
+            "item_count": 1
+          },
+          {
+            "name": "Gold",
+            "item_count": 1
+          },
+          {
+            "name": "Special",
+            "item_count": 1
+          }
+        ],
+        "map_locations": [
+          {
+            "map": "homeworld",
+            "x": 465,
+            "y": 390
           }
         ]
       },

--- a/logic_hortence/stillpond.json
+++ b/logic_hortence/stillpond.json
@@ -32,15 +32,24 @@
         "sections": [
           {
             "name": "Whirlpool Chamber",
-            "item_count": 1
+            "item_count": 1,
+            "access_rules": [
+              "magicseashell"
+            ]
           },
           {
             "name": "\"Catch\"",
-            "item_count": 1
+            "item_count": 1,
+            "access_rules": [
+              "key_fishingdungeon"
+            ]
           },
           {
             "name": "Chef Bass",
-            "item_count": 1
+            "item_count": 1,
+            "access_rules": [
+              "key_fishingdungeon,key_fish"
+            ]
           }
         ],
         "map_locations": [

--- a/logic_hortence/wraith.json
+++ b/logic_hortence/wraith.json
@@ -188,6 +188,7 @@
           {
             "name": "Loremaster",
             "item_count": 1,
+            "hosted_item": "flimsyhammers",
             "access_rules": [
               "qps:11"
             ]
@@ -236,7 +237,7 @@
         "access_rules": [
           "undeathcoin",
           "flame_green",
-          "dweller_dread,mistral"
+          "boss_dweller_dread,mistral"
         ],
         "sections": [
           {
@@ -279,7 +280,7 @@
             "name": "Secret Passage",
             "item_count": 1,
             "access_rules": [
-              "flight,mistral"
+              "boss_dweller_dread,mistral"
             ]
           },
           {
@@ -505,11 +506,11 @@
             "item_count": 1
           },
           {
-            "name": "Upper Pedestal",
+            "name": "Right Side",
             "item_count": 1
           },
           {
-            "name": "Right Side",
+            "name": "Upper Pedestal",
             "item_count": 1,
             "access_rules": [
               "key_wraithshrine"

--- a/logic_vanilla/wraith.json
+++ b/logic_vanilla/wraith.json
@@ -236,7 +236,7 @@
         "access_rules": [
           "undeathcoin",
           "flame_green",
-          "dweller_dread,mistral"
+          "boss_dweller_dread,mistral"
         ],
         "sections": [
           {


### PR DESCRIPTION
Resolve #5 
List of errors to be fixed:

- [x] Romaya's Secret Passage should be available with Dweller of Dread, but currently uses Flight Event
- [x] Wraith Shrine Upper Pedestal and Right Side Chest are logically swapped
- [x] Wheels Champion in Repine should depend on Deployable Wheels Table
- [x] Cerulean Expanse Room 4 name should be "bottom right"
- [x] "Push Crate" in Brisk is a duplication of "rubble secret"
- [x] Cooking with Garl likely needs to be a guaranteed Berry Jam recipe to prevent a softlock; this can be a hosted item
- [x] Graplou Island in Mountain Trail should be a conch, and should be before Pine Path
- [x] Moorlands Pond/Island check should be before Srower cave
- [x] Mines 2B Left check should be a basket
- [x] Cascades West Edge should be a basket
- [x] Brisk Rubble Secret should be dependent on mistral bracelet. Maybe consider "yellow" without, to account for the removal of the push block after Cataclysm.
- [x] 2nd & 3rd checks in Fishing Dungeon should depend on Fish Key
- [x] Mines illusion in Lair should depend on sus fish

List of Missing Locations:

- [x] Dweller's Fall Arena should show both bosses and tier rewards when Dweller of Dread is cleared
- [x] Wheels Champion in Clockwork Castle (Name it "Watchmaker Game?")
- [x] Garl Hook of Time Check
- [x] Mountain Trail Rope Cave
- [x] Zenith Prologue (may not be included later, but implement for completion):
      - [ ] Ornate Stone Checks (2)
      - [ ] Before and After snack checks (2)
- [x] Stonemasons Outpost Wheels Champion in Darro's Studio
- [x] 4 Checks (& bosses) for Dweller's Fall Arena
- [x] 2 Checks for Golden Pelican
- [x] Hole in Roof (alt names: Fireplace, Favorite Meal House) check in Brisk with normal treasure chest
- [x] Add cataclysm checks in code, just for completion
- [x] Soul Curator checklist item in Lair