### PR TITLE
006 Dawn of Equinox Changes

### DIFF
--- a/items/recipes.json
+++ b/items/recipes.json
@@ -57,7 +57,7 @@
     "name": "Recipe: Herbed Filet",
     "type": "toggle",
     "img": "images/items/food_herbedfilet.png",
-    "codes": "food_herbedfilet,food_water"
+    "codes": "food_herbedfilet,food_light,food_water"
   },
   {
     "name": "Recipe: Lasagna",

--- a/logic_hortence/evermist.json
+++ b/logic_hortence/evermist.json
@@ -314,6 +314,12 @@
         ],
         "sections": [
           {
+            "name": "Early Basket",
+            "item_count": 1,
+            "chest_unopened_img": "images/boxes/basket_closed.png",
+            "chest_opened_img": "images/boxes/basket_open.png"
+          },
+          {
             "name": "Luslug Cave",
             "item_count": 1
           },

--- a/logic_hortence/mesa.json
+++ b/logic_hortence/mesa.json
@@ -192,27 +192,6 @@
             "access_rules": [
               "@Songshroom Marsh/Past Crate"
             ]
-          },
-          {
-            "name": "Past Gate",
-            "item_count": 1,
-            "access_rules": [
-              "@Songshroom Marsh/Yomara's Gate"
-            ]
-          },
-          {
-            "name": "Tall Shroom Cave",
-            "item_count": 1,
-            "access_rules": [
-              "@Songshroom Marsh/Yomara's Gate"
-            ]
-          },
-          {
-            "name": "Fungtoise Cave",
-            "item_count": 1,
-            "access_rules": [
-              "@Songshroom Marsh/Yomara's Gate"
-            ]
           }
         ],
         "map_locations": [

--- a/logic_hortence/mesa.json
+++ b/logic_hortence/mesa.json
@@ -126,13 +126,13 @@
         "name": "Songshroom Marsh",
         "access_rules": [
           "@Autumn Hills/Past Prism,magicseashell",
-          "boss_dweller_of_dread"
+          "boss_dweller_dread"
         ],
         "sections": [
           {
             "name": "Past Crate",
             "access_rules": [
-              "mistral"
+              "graplou,mistral"
             ],
             "visibility_rules": [
               "__subregion__"
@@ -140,9 +140,20 @@
             "item_count": 1
           },
           {
-            "name": "Yomara's Gate",
+            "name": "Yomara's House",
             "access_rules": [
-              "mistral,key_yomara"
+              "graplou,mistral",
+              "key_yomara"
+            ],
+            "visibility_rules": [
+              "__subregion__"
+            ],
+            "item_count": 1
+          },
+          {
+            "name": "Beyond Yomara's Gate",
+            "access_rules": [
+              "graplou,mistral,key_yomara"
             ],
             "visibility_rules": [
               "__subregion__"
@@ -180,17 +191,42 @@
             ]
           },
           {
-            "name": "Yomara",
+            "name": "Down the Vine",
             "item_count": 1,
             "access_rules": [
               "@Songshroom Marsh/Past Crate"
             ]
           },
           {
-            "name": "Yomara's Yard",
+            "name": "Mushroom Landing",
+            "item_count": 1,
+            "chest_unopened_img": "images/boxes/combo_scroll_closed.png",
+            "chest_opened_img": "images/boxes/combo_scroll_open.png",
+            "access_rules": [
+              "@Songshroom Marsh/Yomara's House"
+            ]
+          },
+          {
+            "name": "Yomara",
             "item_count": 1,
             "access_rules": [
-              "@Songshroom Marsh/Past Crate"
+              "@Songshroom Marsh/Yomara's House"
+            ]
+          },
+          {
+            "name": "Yomara's Yard",
+            "item_count": 1,
+            "chest_unopened_img": "images/boxes/conch_chest_closed.png",
+            "chest_opened_img": "images/boxes/conch_chest_open.png",
+            "access_rules": [
+              "@Songshroom Marsh/Yomara's House"
+            ]
+          },
+          {
+            "name": "Yomara's Garden",
+            "item_count": 1,
+            "access_rules": [
+              "@Songshroom Marsh/Yomara's House"
             ]
           }
         ],
@@ -205,7 +241,7 @@
       {
         "name": "Clockwork Castle Grounds",
         "access_rules": [
-          "@Songshroom Marsh/Yomara's Gate"
+          "@Songshroom Marsh/Beyond Yomara's Gate"
         ],
         "sections": [
           {


### PR DESCRIPTION
Resolve #6 
List of Changed Locations:

- [x] Chomper: Include Herbed Filet under the "Light" requirement

List of New Locations:

- [x] Mountain Trail Basket to the left of graplou island, no requirements
- [x] Songshroom chest after fort, below stone graplou post
- [x] Songshroom Scroll after bouncing mushrooms
- [x] Songshroom chest in Yomara's Garden

List of Removed Locations:

- [x] End of Songshroom Marsh past Yomara's Gate (3 checks)