### PR TITLE
Rewriting Ascended Trials + fix

### DIFF
--- a/logic_hortence/__rules.json
+++ b/logic_hortence/__rules.json
@@ -23,15 +23,17 @@
   {
     "name": "rule_can_get_zephyr",
     "access_rules": [
-      "key_wind,cobalthammer"
+      "@rule_can_leave_cavern,@rule_can_sail,boss_dweller_strife,key_wind,cobalthammer",
+      "@rule_can_leave_cavern,@rule_can_sail,golem_puntie,key_wind,cobalthammer",
+      "@rule_can_leave_cavern,@rule_can_sail,option_skybridge_open,key_wind,cobalthammer"
     ]
   },
   {
     "name": "rule_can_cross_sea_of_stars",
     "access_rules": [
-      "@rule_can_sail,@rule_can_get_zephyr,boss_toadcano,boss_hydralion,magicseashell",
-      "@rule_can_sail,option_sos_mshell,magicseashell",
-      "@rule_can_sail,option_sos_open"
+      "@rule_can_leave_cavern,@rule_can_sail,@rule_can_get_zephyr,boss_toadcano,boss_hydralion,magicseashell",
+      "@rule_can_leave_cavern,@rule_can_sail,option_sos_mshell,magicseashell",
+      "@rule_can_leave_cavern,@rule_can_sail,option_sos_open"
     ]
   },
   {

--- a/logic_hortence/evermist.json
+++ b/logic_hortence/evermist.json
@@ -316,10 +316,6 @@
             "item_count": 1,
             "chest_unopened_img": "images/boxes/dungeon_chest_purple_closed.png",
             "chest_opened_img": "images/boxes/dungeon_chest_purple_open.png"
-          },
-          {
-            "name": "Elder Dissed",
-            "hosted_item": "boss_eldermist"
           }
         ],
         "map_locations": [
@@ -381,26 +377,35 @@
           {
             "name": "Mist Falls",
             "item_count": 1
-          },
-          {
-            "name": "Elder Mist Refight",
-            "access_rules": [
-              "@Wraith Solstice Shrine,@Evermist Solstice Shrine"
-            ],
-            "hosted_item": "boss_eldermist_2"
-          },
-          {
-            "name": "Elder Dissed",
-            "access_rules": [
-              "@Wraith Solstice Shrine,@Evermist Solstice Shrine,boss_dweller_dread,amulet,mistral"
-            ],
-            "item_count": 2
           }
         ],
         "map_locations": [
           {
             "map": "homeworld",
             "x": 283,
+            "y": 730
+          }
+        ]
+      },
+      {
+        "name": "Ascended Warriors Trial",
+        "access_rules": [
+          "@rule_can_leave_cavern,@rule_can_fly,@rule_can_cross_sea_of_stars,key_evermistshrine,graplou,key_wraithshrine:2,amulet,mistral"
+        ],
+        "sections": [
+          {
+            "name": "Elder Mist",
+            "hosted_item": "boss_eldermist_2"
+          },
+          {
+            "name": "Elder Dissed",
+            "item_count": 2
+          }
+        ],
+        "map_locations": [
+          {
+            "map": "homeworld",
+            "x": 298,
             "y": 730
           }
         ]

--- a/logic_hortence/home_overworld.json
+++ b/logic_hortence/home_overworld.json
@@ -45,9 +45,6 @@
               {
                 "name": "Shrine Reward",
                 "item_count": 1,
-                "access_rules": [
-                  "amulet"
-                ],
                 "chest_unopened_img": "images/boxes/dungeon_chest_purple_closed.png",
                 "chest_opened_img": "images/boxes/dungeon_chest_purple_open.png"
               }


### PR DESCRIPTION
New name for postgame elder mist area: Ascended Warriors Trial
Now independent of regions, and makes use of rules and absolute logic
Also fixed Zephyr logic error that assumed availability without access to Skylands