### PR TITLE
FIx logic error romaya's journal

### DIFF
--- a/logic_hortence/wraith.json
+++ b/logic_hortence/wraith.json
@@ -356,14 +356,14 @@
             "name": "Give Journal",
             "item_count": 1,
             "access_rules": [
-              "k_journal"
+              "k_mistral,k_journal"
             ]
           },
           {
             "name": "Give Locket",
             "item_count": 1,
             "access_rules": [
-              "k_locket"
+              "k_mistral,k_journal,k_locket"
             ]
           },
           {


### PR DESCRIPTION
Added mistral requirement to both the Give Journal and Give Locket locations. Made Journal required for Give Locket.
Effect should be that players have to:
- reach Duke at his boss fight first (mistral required)
- then reach him with journal at the top left of the pond by the secret door
- then find him with locket at the bottom left of FG by his tomb

Ideally in future this could function like OOT trade quest where Duke appears at convenient locations based on your inventory, so the sequence is not strict, but for now assume this required procedure.